### PR TITLE
Accordion fails to open on first load

### DIFF
--- a/css/input.css
+++ b/css/input.css
@@ -68,11 +68,10 @@
 	padding: 10px 10px 0 10px;
 }
 .acf-accordion-group.opened {
-	display: block;
-}
-
-.acf-tab_group-show.acf-accordion-group.opened {
     display: block;
+}
+.acf-tab_group-hide.acf-accordion-group.opened {
+    display: none;
 }
 .acf-tab_group-show.acf-accordion-group.opened .acf-tab_group-hide {
 	display: block;

--- a/css/input.css
+++ b/css/input.css
@@ -67,6 +67,9 @@
 	display: none;
 	padding: 10px 10px 0 10px;
 }
+.acf-accordion-group.opened {
+	display: block;
+}
 
 .acf-tab_group-show.acf-accordion-group.opened {
     display: block;


### PR DESCRIPTION
Sometimes, when you first load the editor page, the accordion fails to open. Seems that ACF adds some classes only when you interact with the tab system.

I think I've managed to fix that and retain previous fixes.